### PR TITLE
Xtext 2.8 support

### DIFF
--- a/releng/hu.bme.mit.massif.releng/hu.bme.mit.massif.releng.target
+++ b/releng/hu.bme.mit.massif.releng/hu.bme.mit.massif.releng.target
@@ -3,12 +3,18 @@
 <target name="Generated from Massif Targlet Platform" sequenceNumber="50">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="org.eclipse.emf.sdk.feature.group" version="2.10.2.v20150123-0452"/>
       <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="1.8.0.201405281451"/>
       <unit id="org.eclipse.equinox.sdk.feature.group" version="3.10.2.v20150204-1316"/>
       <unit id="org.eclipse.sdk.feature.group" version="4.4.2.v20150204-1700"/>
-      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.7.3.v201411190455"/>
       <repository location="http://download.eclipse.org/releases/luna"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <unit id="org.eclipse.emf.sdk.feature.group" version="2.10.2.v20150123-0452"/>
+      <repository location="http://download.eclipse.org/modeling/emf/emf/updates/2.10.x/"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.8.1.v201503230617"/>
+      <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
     </location>
   </locations>
 </target>

--- a/setup/hu.bme.mit.massif.setup/Massif.setup
+++ b/setup/hu.bme.mit.massif.setup/Massif.setup
@@ -477,7 +477,7 @@
             name="org.eclipse.sdk.feature.group"/>
         <requirement
             name="org.eclipse.xtext.sdk.feature.group"
-            versionRange="[2.7.0,2.8.0)"/>
+            versionRange="[2.8.0,2.9.0)"/>
         <requirement
             name="org.eclipse.emf.sdk.feature.group"
             versionRange="[2.9.0,3.0.0)"/>


### PR DESCRIPTION
Updated requirements to refer to Xtext 2.8 instead of Xtext 2.7 to be in synch with EMF-IncQuery master.