### PR TITLE
Add a preference for selecting a different Matlab version

### DIFF
--- a/plugins/hu.bme.mit.massif.communication.matlabcontrol/src/hu/bme/mit/massif/communication/matlabcontrol/CommandEvaluatorMCImpl.java
+++ b/plugins/hu.bme.mit.massif.communication.matlabcontrol/src/hu/bme/mit/massif/communication/matlabcontrol/CommandEvaluatorMCImpl.java
@@ -44,14 +44,15 @@ public class CommandEvaluatorMCImpl implements ICommandEvaluator {
 	
     public CommandEvaluatorMCImpl(String matlabPath) {
     	
+        if (matlabPath != "") {
     	optionsBuilder = optionsBuilder.setMatlabLocation(matlabPath);
+        }
     	options = optionsBuilder.build();
     	factory = new MatlabProxyFactory(options);
     	
         try {
 			proxy = factory.getProxy();
 		} catch (MatlabConnectionException e) {
-			e.printStackTrace();
 		}
     }
 

--- a/plugins/hu.bme.mit.massif.communication.matlabcontrol/src/hu/bme/mit/massif/communication/matlabcontrol/CommandEvaluatorMCImpl.java
+++ b/plugins/hu.bme.mit.massif.communication.matlabcontrol/src/hu/bme/mit/massif/communication/matlabcontrol/CommandEvaluatorMCImpl.java
@@ -26,6 +26,8 @@ import matlabcontrol.MatlabConnectionException;
 import matlabcontrol.MatlabInvocationException;
 import matlabcontrol.MatlabProxy;
 import matlabcontrol.MatlabProxyFactory;
+import matlabcontrol.MatlabProxyFactoryOptions;
+import matlabcontrol.MatlabProxyFactoryOptions.Builder;
 
 /**
  * Class responsible for the low level operations with MATLAB
@@ -33,15 +35,23 @@ import matlabcontrol.MatlabProxyFactory;
  * (The successor class of BasicOperationsApi utility class)
  */
 public class CommandEvaluatorMCImpl implements ICommandEvaluator {
-
-	private static MatlabProxyFactory factory = new MatlabProxyFactory();
+	
+	private static MatlabProxyFactory factory = null;
 	private static MatlabProxy proxy = null;
-	    
-    public CommandEvaluatorMCImpl() {
+	
+	private Builder optionsBuilder = new MatlabProxyFactoryOptions.Builder();
+	private MatlabProxyFactoryOptions options = null;
+	
+    public CommandEvaluatorMCImpl(String matlabPath) {
+    	
+    	optionsBuilder = optionsBuilder.setMatlabLocation(matlabPath);
+    	options = optionsBuilder.build();
+    	factory = new MatlabProxyFactory(options);
+    	
         try {
 			proxy = factory.getProxy();
 		} catch (MatlabConnectionException e) {
-			
+			e.printStackTrace();
 		}
     }
 

--- a/plugins/hu.bme.mit.massif.communication.matlabcontrol/src/hu/bme/mit/massif/communication/matlabcontrol/MatlabControlCommandEvaluatorFactory.java
+++ b/plugins/hu.bme.mit.massif.communication.matlabcontrol/src/hu/bme/mit/massif/communication/matlabcontrol/MatlabControlCommandEvaluatorFactory.java
@@ -24,7 +24,11 @@ public class MatlabControlCommandEvaluatorFactory implements ICommandEvaluatorFa
 	@Override
 	public ICommandEvaluator createCommandEvaluator(
 			Map<String, Object> parameters) {
-		ICommandEvaluator result = new CommandEvaluatorMCImpl();
+		// Get the parameters
+		String matlabPath = (String) parameters.get("matlabPath");
+		
+		ICommandEvaluator result = new CommandEvaluatorMCImpl(matlabPath);
+		
         return result;
 	}
 

--- a/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/handlers/AbstractSimulinkHandler.java
+++ b/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/handlers/AbstractSimulinkHandler.java
@@ -47,11 +47,14 @@ public abstract class AbstractSimulinkHandler extends AbstractHandler {
         String hostAddress = getPreferenceStringValue(PreferenceConstants.HOST_ADDRESS, "127.0.0.1");
         String hostPortString = getPreferenceStringValue(PreferenceConstants.HOST_PORT, "0");
         int hostPort = Integer.parseInt(hostPortString);
+        String matlabPath = getPreferenceStringValue(PreferenceConstants.MATLAB_PATH, "");
+        
         // Adding the current path of the model to the MATLAB path so that it is able to find it
         Map<String, Object> evaluatorParameters = new HashMap<String, Object>();
         evaluatorParameters.put(PreferenceConstants.HOST_ADDRESS, hostAddress);
         evaluatorParameters.put(PreferenceConstants.HOST_PORT, hostPort);
         evaluatorParameters.put(PreferenceConstants.SERVICE_NAME, serviceName);
+        evaluatorParameters.put(PreferenceConstants.MATLAB_PATH, matlabPath);
 
         String matlabConnectorId = getMatlabConnector();
     	ICommandEvaluator commandEvaluator = null;

--- a/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/PreferenceConstants.java
+++ b/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/PreferenceConstants.java
@@ -21,6 +21,7 @@ public class PreferenceConstants {
 	public static final String HOST_PORT = "hostPort";
 	public static final String SERVICE_NAME = "serviceName";
 	public static final String MATLAB_CONNECTOR = "matlab_connector";
+	public static final String MATLAB_PATH = "matlabPath";
 	
 	// Import
 	public static final String IMPORT_TRAVERSE_MODE = "traverseMode";

--- a/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/PreferenceInitializer.java
+++ b/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/PreferenceInitializer.java
@@ -37,6 +37,7 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
         // Global
         store.setDefault(PreferenceConstants.HOST_ADDRESS, "127.0.0.1");
         store.setDefault(PreferenceConstants.HOST_PORT, 1098);
+        store.setDefault(PreferenceConstants.MATLAB_PATH, "");
 
         // Import
         store.setDefault(PreferenceConstants.IMPORT_TRAVERSE_MODE, ImportMode.SHALLOW.toString());

--- a/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/SimulinkPreferencePage.java
+++ b/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/SimulinkPreferencePage.java
@@ -51,7 +51,7 @@ public class SimulinkPreferencePage extends FieldEditorPreferencePage implements
         addField(new StringFieldEditor(PreferenceConstants.HOST_ADDRESS, "Host IPv4 address:", getFieldEditorParent()));
         addField(new IntegerFieldEditor(PreferenceConstants.HOST_PORT, "Host port number:", getFieldEditorParent()));
         addField(new StringFieldEditor(PreferenceConstants.SERVICE_NAME, "Service name:", getFieldEditorParent()));
-        addField(new StringFieldEditor(PreferenceConstants.MATLAB_PATH, "Path to Matlab executable", getFieldEditorParent()));
+        addField(new StringFieldEditor(PreferenceConstants.MATLAB_PATH, "(optional - MatlabControl only) Path to Matlab executable", getFieldEditorParent()));
         
         String[][] connectors = processAvailableConnectors();
         addField(new ComboFieldEditor(PreferenceConstants.MATLAB_CONNECTOR, "Matlab Connector", connectors, getFieldEditorParent()));

--- a/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/SimulinkPreferencePage.java
+++ b/plugins/hu.bme.mit.massif.simulink.importer.ui/src/hu/bme/mit/massif/simulink/importer/ui/preferences/SimulinkPreferencePage.java
@@ -51,6 +51,7 @@ public class SimulinkPreferencePage extends FieldEditorPreferencePage implements
         addField(new StringFieldEditor(PreferenceConstants.HOST_ADDRESS, "Host IPv4 address:", getFieldEditorParent()));
         addField(new IntegerFieldEditor(PreferenceConstants.HOST_PORT, "Host port number:", getFieldEditorParent()));
         addField(new StringFieldEditor(PreferenceConstants.SERVICE_NAME, "Service name:", getFieldEditorParent()));
+        addField(new StringFieldEditor(PreferenceConstants.MATLAB_PATH, "Path to Matlab executable", getFieldEditorParent()));
         
         String[][] connectors = processAvailableConnectors();
         addField(new ComboFieldEditor(PreferenceConstants.MATLAB_CONNECTOR, "Matlab Connector", connectors, getFieldEditorParent()));


### PR DESCRIPTION
Add a preference for selecting a different matlab version.

Known issues:
- The preference is always visible, even if matlab control is not used
- No tests
- No documentation

Tested on mac os X (worksforme).

Important Disclaimer: I’m not a java programmer…

Signed-off-by: Klaas Gadeyne <klaas.gadeyne@gmail.com>